### PR TITLE
Optional build - check if go executable is on the path, skip otherwise

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -16,11 +16,19 @@
     specific language governing permissions and limitations
     under the License.
 -->
-<project name="CLI" >
+<project name="CLI"
+    xmlns:if="ant:if"
+    xmlns:unless="ant:unless">
+
     <property name="build.script" location="${basedir}/release/build.sh"/>
 
-      <target name="all" >
-        <exec executable="${build.script}" failonerror="true">
+    <property environment="env" />
+    <available file="go"
+             filepath="${env.PATH}"
+             property="go.present"/>
+
+    <target name="all">
+        <exec executable="${build.script}" failonerror="true" if:set="go.present">
             <arg value="-A"/>
             <arg value="-t"/>
             <arg value="-d"/>
@@ -28,10 +36,14 @@
             <arg value="-s"/>
             <arg value="${basedir}"/>
         </exec>
+        <echo unless:set="go.present">
+            GO compiler not found on classpath, skipping brooklyn-client-cli build
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        </echo>
     </target>
 
-    <target name="cross" >
-        <exec executable="${build.script}" failonerror="true">
+    <target name="cross">
+        <exec executable="${build.script}" failonerror="true" if:set="go.present">
             <arg value="-t"/>
             <arg value="-a"/>
             <arg value="${arch}"/>
@@ -42,15 +54,23 @@
             <arg value="-s"/>
             <arg value="${basedir}"/>
         </exec>
+        <echo unless:set="go.present">
+            GO compiler not found on classpath, skipping brooklyn-client-cli build
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        </echo>
     </target>
 
-    <target name="native" >
-        <exec executable="${build.script}" failonerror="true">
+    <target name="native">
+        <exec executable="${build.script}" failonerror="true" if:set="go.present">
             <arg value="-d"/>
             <arg value="${project.build.directory}"/>
             <arg value="-s"/>
             <arg value="${basedir}"/>
         </exec>
+        <echo unless:set="go.present">
+            GO compiler not found on classpath, skipping brooklyn-client-cli build
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        </echo>
     </target>
 
 </project>


### PR DESCRIPTION
Improve first time experience, don't require GO compiler installed for full build. Will skip building the executables, but still create the zip file.

Should we instead require that GO is installed?