### PR TITLE
Inherit parent pom as do other brooklyn-* modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,11 +23,16 @@
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.brooklyn</groupId>
+        <artifactId>brooklyn-parent</artifactId>
+        <version>0.9.0-SNAPSHOT</version>  <!-- BROOKLYN_VERSION -->
+        <relativePath>../brooklyn-server/parent/</relativePath>
+    </parent>
+    
     <packaging>pom</packaging>
 
-    <groupId>org.apache.brooklyn</groupId>
     <artifactId>brooklyn-client-cli</artifactId>
-    <version>0.9.0-SNAPSHOT</version>  <!-- BROOKLYN_VERSION -->
     <name>Brooklyn Client Command Line Interface</name>
     <description>
         A command line client for Apache Brooklyn


### PR DESCRIPTION
This is to address

[ERROR] No Repository settings defined in the job configuration or distributionManagement of the module.

upon Apache build.