### PR TITLE
Minor README update to remove remark redundant since vendoring added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A command line client for [Apache Brooklyn](https://brooklyn.apache.org).
 The CLI tool is written in Go and should be obtained and built as a standard Go project. 
 You will need the following tools to build it:
 
-- Go (min version 1.6), with full cross-compiler support (see https://golang.org/dl).
+- Go (version 1.6.1 or higher), with full cross-compiler support (see https://golang.org/dl).
   On Mac, if using Homebrew, use "brew install go --with-cc-all"
 
 Optional:

--- a/README.md
+++ b/README.md
@@ -28,10 +28,9 @@ own fork as a remote.
 
 - Ensure your [$GOPATH](http://golang.org/cmd/go/#hdr-GOPATH_environment_variable) is set correctly 
   to a suitable location for your Go code, for example, simply $HOME/go.
-- Get the Brooklyn CLI and dependencies. Note the "-d" parameter, which instructs Go to download the files but not
-  build the code, see why in the note below on dependency management.
+- Get the Brooklyn CLI and dependencies. 
 
-`go get -d github.com/apache/brooklyn-client/br`  
+`go get github.com/apache/brooklyn-client/br`  
 
     
 ## A note on dependency management


### PR DESCRIPTION
also adds recommendation to use Go 1.6.1 due to https://groups.google.com/forum/m/#!msg/golang-announce/9eqIHqaWvck/kXsfO0ogLAAJ