### PR TITLE
Adds support for Plugins

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -21,12 +21,16 @@ package app
 import (
 	"fmt"
 	"github.com/apache/brooklyn-client/command_metadata"
-	"github.com/apache/brooklyn-client/command_runner"
 	"github.com/apache/brooklyn-client/error_handler"
 	"github.com/codegangsta/cli"
 	"os"
 	"strings"
 )
+
+type Runner interface {
+	RunCmdByName(cmdName string, c *cli.Context) (err error)
+	RunSubCmdByName(cmdName string, subCommand string, c *cli.Context) (err error)
+}
 
 type configDefaults struct {
 	Name     string
@@ -42,7 +46,7 @@ var appConfig = configDefaults{
 	Version:  "0.9.0",
 }
 
-func NewApp(baseName string, cmdRunner command_runner.Runner, metadatas ...command_metadata.CommandMetadata) (app *cli.App) {
+func NewApp(baseName string, cmdRunner Runner, metadatas ...command_metadata.CommandMetadata) (app *cli.App) {
 
 	cli.AppHelpTemplate = appHelpTemplate()
 	cli.CommandHelpTemplate = commandHelpTemplate()
@@ -61,7 +65,7 @@ func NewApp(baseName string, cmdRunner command_runner.Runner, metadatas ...comma
 	return
 }
 
-func getCommand(baseName string, metadata command_metadata.CommandMetadata, runner command_runner.Runner) cli.Command {
+func getCommand(baseName string, metadata command_metadata.CommandMetadata, runner Runner) cli.Command {
 	command := cli.Command{
 		Name:        metadata.Name,
 		Aliases:     metadata.Aliases,
@@ -100,7 +104,7 @@ func getCommand(baseName string, metadata command_metadata.CommandMetadata, runn
 	return command
 }
 
-func subCommandAction(command string, operand string, runner command_runner.Runner) func(context *cli.Context) {
+func subCommandAction(command string, operand string, runner Runner) func(context *cli.Context) {
 	return func(context *cli.Context) {
 		err := runner.RunSubCmdByName(command, operand, context)
 		if err != nil {

--- a/command_factory/factory.go
+++ b/command_factory/factory.go
@@ -62,6 +62,7 @@ func NewFactory(network *net.Network, config *io.Config) (factory concreteFactor
 	factory.simpleCommand(commands.NewDestroyPolicy(network))
 	factory.simpleCommand(commands.NewEffector(network))
 	factory.simpleCommand(commands.NewEntity(network))
+	factory.simpleCommand(commands.NewInstallPlugin(config))
 	factory.simpleCommand(commands.NewInvoke(network))
 	factory.simpleCommand(commands.NewInvokeRestart(network))
 	factory.simpleCommand(commands.NewInvokeStart(network))

--- a/command_runner/runner.go
+++ b/command_runner/runner.go
@@ -19,7 +19,8 @@
 package command_runner
 
 import (
-	"github.com/apache/brooklyn-client/command_factory"
+	"github.com/apache/brooklyn-client/command"
+	"github.com/apache/brooklyn-client/command_metadata"
 	"github.com/apache/brooklyn-client/scope"
 	"github.com/codegangsta/cli"
 )
@@ -29,14 +30,22 @@ type Runner interface {
 	RunSubCmdByName(cmdName string, subCommand string, c *cli.Context) (err error)
 }
 
+type Factory interface {
+	GetByCmdName(cmdName string) (cmd command.Command, err error)
+	GetBySubCmdName(cmdName string, subCmdName string) (cmd command.Command, err error)
+	CommandMetadatas() []command_metadata.CommandMetadata
+}
+
 type ConcreteRunner struct {
-	cmdFactory command_factory.Factory
+	cmdFactory Factory
 	scope      scope.Scope
 }
 
-func NewRunner(scope scope.Scope, cmdFactory command_factory.Factory) (runner ConcreteRunner) {
-	runner.cmdFactory = cmdFactory
-	runner.scope = scope
+func NewRunner(scope scope.Scope, cmdFactory Factory) (runner Runner) {
+	runner = &ConcreteRunner{
+		cmdFactory: cmdFactory,
+		scope:      scope,
+	}
 	return
 }
 

--- a/commands/access.go
+++ b/commands/access.go
@@ -55,5 +55,5 @@ func (cmd *Access) Run(scope scope.Scope, c *cli.Context) {
 	if nil != err {
 		error_handler.ErrorExit(err)
 	}
-	fmt.Println("Location Provisioning Allowed:", access.LocationProvisioningAllowed)
+	fmt.Fprintln(c.App.Writer, "Location Provisioning Allowed:", access.LocationProvisioningAllowed)
 }

--- a/commands/activity-stream.go
+++ b/commands/activity-stream.go
@@ -112,7 +112,7 @@ func (cmd *ActivityStreamEnv) Run(scope scope.Scope, c *cli.Context) {
 	if nil != err {
 		error_handler.ErrorExit(err)
 	}
-	fmt.Println(activityStream)
+	fmt.Fprintln(c.App.Writer, activityStream)
 }
 
 func (cmd *ActivityStreamStderr) Run(scope scope.Scope, c *cli.Context) {
@@ -123,7 +123,7 @@ func (cmd *ActivityStreamStderr) Run(scope scope.Scope, c *cli.Context) {
 	if nil != err {
 		error_handler.ErrorExit(err)
 	}
-	fmt.Println(activityStream)
+	fmt.Fprintln(c.App.Writer, activityStream)
 }
 
 func (cmd *ActivityStreamStdin) Run(scope scope.Scope, c *cli.Context) {
@@ -134,7 +134,7 @@ func (cmd *ActivityStreamStdin) Run(scope scope.Scope, c *cli.Context) {
 	if nil != err {
 		error_handler.ErrorExit(err)
 	}
-	fmt.Println(activityStream)
+	fmt.Fprintln(c.App.Writer, activityStream)
 }
 
 func (cmd *ActivityStreamStdout) Run(scope scope.Scope, c *cli.Context) {
@@ -145,5 +145,5 @@ func (cmd *ActivityStreamStdout) Run(scope scope.Scope, c *cli.Context) {
 	if nil != err {
 		error_handler.ErrorExit(err)
 	}
-	fmt.Println(activityStream)
+	fmt.Fprintln(c.App.Writer, activityStream)
 }

--- a/commands/activity.go
+++ b/commands/activity.go
@@ -37,6 +37,7 @@ import (
 
 type Activity struct {
 	network *net.Network
+	c       *cli.Context
 }
 
 func NewActivity(network *net.Network) (cmd *Activity) {
@@ -61,6 +62,7 @@ func (cmd *Activity) Metadata() command_metadata.CommandMetadata {
 }
 
 func (cmd *Activity) Run(scope scope.Scope, c *cli.Context) {
+	cmd.c = c
 	if err := net.VerifyLoginURL(cmd.network); err != nil {
 		error_handler.ErrorExit(err)
 	}
@@ -85,7 +87,7 @@ func (cmd *Activity) show(activityId string) {
 		error_handler.ErrorExit(err)
 	}
 
-	table := terminal.NewTable([]string{"Id:", activity.Id})
+	table := terminal.NewTable(cmd.c, []string{"Id:", activity.Id})
 	table.Add("DisplayName:", activity.DisplayName)
 	table.Add("Description:", activity.Description)
 	table.Add("EntityId:", activity.EntityId)
@@ -118,7 +120,7 @@ func (cmd *Activity) list(application, entity string) {
 	if nil != err {
 		error_handler.ErrorExit(err)
 	}
-	table := terminal.NewTable([]string{"Id", "Task", "Submitted", "Status", "Streams"})
+	table := terminal.NewTable(cmd.c, []string{"Id", "Task", "Submitted", "Status", "Streams"})
 	for _, activity := range activityList {
 		table.Add(activity.Id,
 			truncate(activity.DisplayName),
@@ -133,7 +135,7 @@ func (cmd *Activity) listchildren(activity string) {
 	if nil != err {
 		error_handler.ErrorExit(err)
 	}
-	table := terminal.NewTable([]string{"Id", "Task", "Submitted", "Status", "Streams"})
+	table := terminal.NewTable(cmd.c, []string{"Id", "Task", "Submitted", "Status", "Streams"})
 	for _, activity := range activityList {
 		table.Add(activity.Id,
 			truncate(activity.DisplayName),

--- a/commands/add-catalog.go
+++ b/commands/add-catalog.go
@@ -55,5 +55,5 @@ func (cmd *AddCatalog) Run(scope scope.Scope, c *cli.Context) {
 	if nil != err {
 		error_handler.ErrorExit(err)
 	}
-	fmt.Println(create)
+	fmt.Fprintln(c.App.Writer, create)
 }

--- a/commands/add-children.go
+++ b/commands/add-children.go
@@ -56,7 +56,7 @@ func (cmd *AddChildren) Run(scope scope.Scope, c *cli.Context) {
 	if nil != err {
 		error_handler.ErrorExit(err)
 	}
-	table := terminal.NewTable([]string{"Id", "Task", "Submitted", "Status"})
+	table := terminal.NewTable(c, []string{"Id", "Task", "Submitted", "Status"})
 	table.Add(activity.Id, activity.DisplayName, time.Unix(activity.SubmitTimeUtc/1000, 0).Format(time.UnixDate), activity.CurrentStatus)
 
 	table.Print()

--- a/commands/application.go
+++ b/commands/application.go
@@ -35,6 +35,7 @@ import (
 
 type Application struct {
 	network *net.Network
+	c       *cli.Context
 }
 
 func NewApplication(network *net.Network) (cmd *Application) {
@@ -54,6 +55,7 @@ func (cmd *Application) Metadata() command_metadata.CommandMetadata {
 }
 
 func (cmd *Application) Run(scope scope.Scope, c *cli.Context) {
+	cmd.c = c
 	if err := net.VerifyLoginURL(cmd.network); err != nil {
 		error_handler.ErrorExit(err)
 	}
@@ -83,7 +85,7 @@ func (cmd *Application) show(appName string) {
 	if nil != err {
 		error_handler.ErrorExit(err)
 	}
-	table := terminal.NewTable([]string{"Id:", application.Id})
+	table := terminal.NewTable(cmd.c, []string{"Id:", application.Id})
 	table.Add("Name:", application.Spec.Name)
 	table.Add("Status:", string(application.Status))
 	if serviceUp, ok := state[serviceIsUpStr]; ok {
@@ -103,7 +105,7 @@ func (cmd *Application) list() {
 	if nil != err {
 		error_handler.ErrorExit(err)
 	}
-	table := terminal.NewTable([]string{"Id", "Name", "Status", "Location"})
+	table := terminal.NewTable(cmd.c, []string{"Id", "Name", "Status", "Location"})
 	for _, app := range applications {
 		table.Add(app.Id, app.Spec.Name, string(app.Status), strings.Join(app.Spec.Locations, ", "))
 	}

--- a/commands/catalog.go
+++ b/commands/catalog.go
@@ -55,7 +55,7 @@ func (cmd *Catalog) Run(scope scope.Scope, c *cli.Context) {
 	if nil != err {
 		error_handler.ErrorExit(err)
 	}
-	table := terminal.NewTable([]string{"Id", "Name", "Description"})
+	table := terminal.NewTable(c, []string{"Id", "Name", "Description"})
 	for _, app := range catalog {
 		table.Add(app.Id, app.Name, app.Description)
 	}

--- a/commands/config.go
+++ b/commands/config.go
@@ -62,14 +62,14 @@ func (cmd *Config) Run(scope scope.Scope, c *cli.Context) {
 		if nil != err {
 			error_handler.ErrorExit(err)
 		}
-		fmt.Println(displayValue)
+		fmt.Fprintln(c.App.Writer, displayValue)
 
 	} else {
 		config, err := entity_config.ConfigCurrentState(cmd.network, scope.Application, scope.Entity)
 		if nil != err {
 			error_handler.ErrorExit(err)
 		}
-		table := terminal.NewTable([]string{"Key", "Value"})
+		table := terminal.NewTable(c, []string{"Key", "Value"})
 		for key, value := range config {
 			table.Add(key, fmt.Sprintf("%v", value))
 		}

--- a/commands/delete.go
+++ b/commands/delete.go
@@ -55,5 +55,5 @@ func (cmd *Delete) Run(scope scope.Scope, c *cli.Context) {
 	if nil != err {
 		error_handler.ErrorExit(err)
 	}
-	fmt.Println(del)
+	fmt.Fprintln(c.App.Writer, del)
 }

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -78,7 +78,7 @@ func (cmd *Deploy) Run(scope scope.Scope, c *cli.Context) {
 			error_handler.ErrorExit(err)
 		}
 	}
-	table := terminal.NewTable([]string{"Id:", create.EntityId})
+	table := terminal.NewTable(c, []string{"Id:", create.EntityId})
 	table.Add("Name:", create.EntityDisplayName)
 	table.Add("Status:", create.CurrentStatus)
 	table.Print()

--- a/commands/destroy-policy.go
+++ b/commands/destroy-policy.go
@@ -55,5 +55,5 @@ func (cmd *DestroyPolicy) Run(scope scope.Scope, c *cli.Context) {
 	if nil != err {
 		error_handler.ErrorExit(err)
 	}
-	fmt.Println(spec)
+	fmt.Fprintln(c.App.Writer, spec)
 }

--- a/commands/effector.go
+++ b/commands/effector.go
@@ -56,7 +56,7 @@ func (cmd *Effector) Run(scope scope.Scope, c *cli.Context) {
 	if nil != err {
 		error_handler.ErrorExit(err)
 	}
-	table := terminal.NewTable([]string{"Name", "Description", "Parameters"})
+	table := terminal.NewTable(c, []string{"Name", "Description", "Parameters"})
 	for _, effector := range effectors {
 		var parameters []string
 		for _, parameter := range effector.Parameters {

--- a/commands/entity.go
+++ b/commands/entity.go
@@ -33,6 +33,7 @@ import (
 
 type Entity struct {
 	network *net.Network
+	c       *cli.Context
 }
 
 func NewEntity(network *net.Network) (cmd *Entity) {
@@ -57,6 +58,7 @@ func (cmd *Entity) Metadata() command_metadata.CommandMetadata {
 }
 
 func (cmd *Entity) Run(scope scope.Scope, c *cli.Context) {
+	cmd.c = c
 	if err := net.VerifyLoginURL(cmd.network); err != nil {
 		error_handler.ErrorExit(err)
 	}
@@ -84,7 +86,7 @@ func (cmd *Entity) show(application, entity string) {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
 		os.Exit(1)
 	}
-	table := terminal.NewTable([]string{"Id:", summary.Id})
+	table := terminal.NewTable(cmd.c, []string{"Id:", summary.Id})
 	table.Add("Name:", summary.Name)
 	configState, err := entity_sensors.CurrentState(cmd.network, application, entity)
 	if nil != err {
@@ -106,7 +108,7 @@ func (cmd *Entity) listapp(application string) {
 	if nil != err {
 		error_handler.ErrorExit(err)
 	}
-	table := terminal.NewTable([]string{"Id", "Name", "Type"})
+	table := terminal.NewTable(cmd.c, []string{"Id", "Name", "Type"})
 	for _, entityitem := range entitiesList {
 		table.Add(entityitem.Id, entityitem.Name, entityitem.Type)
 	}
@@ -119,7 +121,7 @@ func (cmd *Entity) listentity(application string, entity string) {
 		error_handler.ErrorExit(err)
 	}
 
-	table := terminal.NewTable([]string{"Id", "Name", "Type"})
+	table := terminal.NewTable(cmd.c, []string{"Id", "Name", "Type"})
 	for _, entityitem := range entitiesList {
 		table.Add(entityitem.Id, entityitem.Name, entityitem.Type)
 	}

--- a/commands/install-plugin.go
+++ b/commands/install-plugin.go
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package commands
+
+import (
+	"github.com/apache/brooklyn-client/command_metadata"
+	"github.com/apache/brooklyn-client/error_handler"
+	brIO "github.com/apache/brooklyn-client/io"
+	"github.com/apache/brooklyn-client/plugin"
+	"github.com/apache/brooklyn-client/scope"
+	"github.com/codegangsta/cli"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+type InstallPlugin struct {
+	config     *brIO.Config
+	rpcService *plugin.RpcServer
+}
+
+func NewInstallPlugin(config *brIO.Config) (cmd *InstallPlugin) {
+	cmd = new(InstallPlugin)
+	cmd.config = config
+	rpcService, err := plugin.NewRpcServer(nil)
+	if err != nil {
+		error_handler.ErrorExit(err)
+	}
+	cmd.rpcService = rpcService
+	return
+}
+
+func (cmd *InstallPlugin) Metadata() command_metadata.CommandMetadata {
+	return command_metadata.CommandMetadata{
+		Name:        "install-plugin",
+		Aliases:     []string{"install", "ip"},
+		Description: "Install a plugin",
+		Usage:       "BROOKLYN_NAME install-plugin [NAME] [LOCATION]",
+		Flags:       []cli.Flag{},
+	}
+}
+
+func (cmd *InstallPlugin) Run(scope scope.Scope, c *cli.Context) {
+	pluginExecutableName := c.Args()[0]
+	pluginSrcFilepath := c.Args()[1]
+
+	cmd.rpcService.Start()
+	defer cmd.rpcService.Stop()
+	_, err := exec.Command(pluginSrcFilepath, cmd.rpcService.Port(), "Install").Output()
+	if err != nil {
+		log.Fatal(err)
+	}
+	cmd.config.Model.Plugins = make(map[string]*plugin.PluginMetadata)
+	cmd.config.Model.Plugins[pluginExecutableName] = cmd.rpcService.RpcCommand.PluginMetadata
+	cmd.config.Write()
+	pluginDestFilepath := filepath.Join(cmd.config.Model.PluginDir, pluginExecutableName)
+	if err := copy(pluginSrcFilepath, pluginDestFilepath); err != nil {
+		error_handler.ErrorExit(err)
+	}
+}
+
+func copy(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	closeErr := out.Close()
+	if err != nil {
+		return err
+	}
+	return closeErr
+}

--- a/commands/invoke.go
+++ b/commands/invoke.go
@@ -73,9 +73,9 @@ func NewInvokeRestart(network *net.Network) (cmd *Restart) {
 
 var paramFlags = []cli.Flag{
 	cli.StringSliceFlag{
-		Name:  "param, P",
+		Name: "param, P",
 		Usage: "Parameter and value separated by '=', e.g. -P x=y. If the parameter value is complex or multi-" +
-		       "lined it may be provided in a file and referenced as: '@<file>', e.g. -P x=@/path/to/file.",
+			"lined it may be provided in a file and referenced as: '@<file>', e.g. -P x=@/path/to/file.",
 	},
 }
 
@@ -120,7 +120,7 @@ func (cmd *Invoke) Run(scope scope.Scope, c *cli.Context) {
 		error_handler.ErrorExit(err)
 	}
 	parms := c.StringSlice("param")
-	invoke(cmd.network, scope.Application, scope.Entity, scope.Effector, parms)
+	invoke(c, cmd.network, scope.Application, scope.Entity, scope.Effector, parms)
 }
 
 const stopEffector = "stop"
@@ -130,7 +130,7 @@ func (cmd *Stop) Run(scope scope.Scope, c *cli.Context) {
 		error_handler.ErrorExit(err)
 	}
 	parms := c.StringSlice("param")
-	invoke(cmd.network, scope.Application, scope.Entity, stopEffector, parms)
+	invoke(c, cmd.network, scope.Application, scope.Entity, stopEffector, parms)
 }
 
 const startEffector = "start"
@@ -140,7 +140,7 @@ func (cmd *Start) Run(scope scope.Scope, c *cli.Context) {
 		error_handler.ErrorExit(err)
 	}
 	parms := c.StringSlice("param")
-	invoke(cmd.network, scope.Application, scope.Entity, startEffector, parms)
+	invoke(c, cmd.network, scope.Application, scope.Entity, startEffector, parms)
 }
 
 const restartEffector = "restart"
@@ -150,17 +150,17 @@ func (cmd *Restart) Run(scope scope.Scope, c *cli.Context) {
 		error_handler.ErrorExit(err)
 	}
 	parms := c.StringSlice("param")
-	invoke(cmd.network, scope.Application, scope.Entity, restartEffector, parms)
+	invoke(c, cmd.network, scope.Application, scope.Entity, restartEffector, parms)
 }
 
-func invoke(network *net.Network, application, entity, effector string, parms []string) {
+func invoke(c *cli.Context, network *net.Network, application, entity, effector string, parms []string) {
 	names, vals, err := extractParams(parms)
 	result, err := entity_effectors.TriggerEffector(network, application, entity, effector, names, vals)
 	if nil != err {
 		error_handler.ErrorExit(err)
 	} else {
 		if "" != result {
-			fmt.Println(result)
+			fmt.Fprintln(c.App.Writer, result)
 		}
 	}
 }

--- a/commands/locations.go
+++ b/commands/locations.go
@@ -55,7 +55,7 @@ func (cmd *Locations) Run(scope scope.Scope, c *cli.Context) {
 	if nil != err {
 		error_handler.ErrorExit(err)
 	}
-	table := terminal.NewTable([]string{"Id", "Name", "Spec"})
+	table := terminal.NewTable(c, []string{"Id", "Name", "Spec"})
 	for _, location := range locationList {
 		table.Add(location.Id, location.Name, location.Spec)
 	}

--- a/commands/login.go
+++ b/commands/login.go
@@ -85,22 +85,15 @@ func (cmd *Login) Run(scope scope.Scope, c *cli.Context) {
 		cmd.network.BrooklynPass = string(bytePassword)
 	}
 
-	if cmd.config.Map == nil {
-		cmd.config.Map = make(map[string]interface{})
+	if cmd.config.Model.Auth == nil {
+		cmd.config.Model.Auth = make(map[string]io.Credentials)
 	}
-	// now persist these credentials to the yaml file
-	auth, ok := cmd.config.Map["auth"].(map[string]interface{})
-	if !ok {
-		auth = make(map[string]interface{})
-		cmd.config.Map["auth"] = auth
+	cmd.config.Model.Auth[cmd.network.BrooklynUrl] = io.Credentials{
+		Username: cmd.network.BrooklynUser,
+		Password: cmd.network.BrooklynPass,
 	}
 
-	auth[cmd.network.BrooklynUrl] = map[string]string{
-		"username": cmd.network.BrooklynUser,
-		"password": cmd.network.BrooklynPass,
-	}
-
-	cmd.config.Map["target"] = cmd.network.BrooklynUrl
+	cmd.config.Model.Target = cmd.network.BrooklynUrl
 	cmd.config.Write()
 
 	loginVersion, err := version.Version(cmd.network)

--- a/commands/policy.go
+++ b/commands/policy.go
@@ -33,6 +33,7 @@ import (
 
 type Policy struct {
 	network *net.Network
+	c       *cli.Context
 }
 
 type policyConfigList []models.PolicyConfigList
@@ -87,7 +88,7 @@ func (cmd *Policy) show(application, entity, policy string) {
 	if nil != err {
 		error_handler.ErrorExit(err)
 	}
-	table := terminal.NewTable([]string{"Name", "Value", "Description"})
+	table := terminal.NewTable(cmd.c, []string{"Name", "Value", "Description"})
 	var theConfigs policyConfigList = configs
 	sort.Sort(theConfigs)
 
@@ -106,7 +107,7 @@ func (cmd *Policy) list(application, entity string) {
 	if nil != err {
 		error_handler.ErrorExit(err)
 	}
-	table := terminal.NewTable([]string{"Id", "Name", "State"})
+	table := terminal.NewTable(cmd.c, []string{"Id", "Name", "State"})
 	for _, policy := range policies {
 		table.Add(policy.Id, policy.Name, string(policy.State))
 	}

--- a/commands/rename.go
+++ b/commands/rename.go
@@ -55,5 +55,5 @@ func (cmd *Rename) Run(scope scope.Scope, c *cli.Context) {
 	if nil != err {
 		error_handler.ErrorExit(err)
 	}
-	fmt.Println(rename)
+	fmt.Fprintln(c.App.Writer, rename)
 }

--- a/commands/sensor.go
+++ b/commands/sensor.go
@@ -33,6 +33,7 @@ import (
 
 type Sensor struct {
 	network *net.Network
+	c       *cli.Context
 }
 
 type sensorList []models.SensorSummary
@@ -90,7 +91,7 @@ func (cmd *Sensor) show(application, entity, sensor string) {
 	if nil != err {
 		error_handler.ErrorExit(err)
 	}
-	fmt.Println(displayValue)
+	fmt.Fprintln(cmd.c.App.Writer, displayValue)
 }
 
 func (cmd *Sensor) list(application, entity string) {
@@ -99,7 +100,7 @@ func (cmd *Sensor) list(application, entity string) {
 		error_handler.ErrorExit(err)
 	}
 	var theSensors sensorList = sensors
-	table := terminal.NewTable([]string{"Name", "Description", "Value"})
+	table := terminal.NewTable(cmd.c, []string{"Name", "Description", "Value"})
 
 	sort.Sort(theSensors)
 

--- a/commands/set.go
+++ b/commands/set.go
@@ -55,5 +55,5 @@ func (cmd *SetConfig) Run(scope scope.Scope, c *cli.Context) {
 	if nil != err {
 		error_handler.ErrorExit(err)
 	}
-	fmt.Println(response)
+	fmt.Fprintln(c.App.Writer, response)
 }

--- a/commands/spec.go
+++ b/commands/spec.go
@@ -55,5 +55,5 @@ func (cmd *Spec) Run(scope scope.Scope, c *cli.Context) {
 	if nil != err {
 		error_handler.ErrorExit(err)
 	}
-	fmt.Println(spec)
+	fmt.Fprintln(c.App.Writer, spec)
 }

--- a/commands/start-policy.go
+++ b/commands/start-policy.go
@@ -55,5 +55,5 @@ func (cmd *StartPolicy) Run(scope scope.Scope, c *cli.Context) {
 	if nil != err {
 		error_handler.ErrorExit(err)
 	}
-	fmt.Println(spec)
+	fmt.Fprintln(c.App.Writer, spec)
 }

--- a/commands/stop-policy.go
+++ b/commands/stop-policy.go
@@ -55,5 +55,5 @@ func (cmd *StopPolicy) Run(scope scope.Scope, c *cli.Context) {
 	if nil != err {
 		error_handler.ErrorExit(err)
 	}
-	fmt.Println(spec)
+	fmt.Fprintln(c.App.Writer, spec)
 }

--- a/commands/tree.go
+++ b/commands/tree.go
@@ -31,6 +31,7 @@ import (
 
 type Tree struct {
 	network *net.Network
+	c       *cli.Context
 }
 
 func NewTree(network *net.Network) (cmd *Tree) {
@@ -49,6 +50,7 @@ func (cmd *Tree) Metadata() command_metadata.CommandMetadata {
 }
 
 func (cmd *Tree) Run(scope scope.Scope, c *cli.Context) {
+	cmd.c = c
 	if err := net.VerifyLoginURL(cmd.network); err != nil {
 		error_handler.ErrorExit(err)
 	}
@@ -66,8 +68,8 @@ func (cmd *Tree) printTrees(trees []models.Tree, indent string) {
 }
 
 func (cmd *Tree) printTree(tree models.Tree, indent string, last bool) {
-	fmt.Println(indent+"|-", tree.Name)
-	fmt.Println(indent+"+-", tree.Type)
+	fmt.Fprintln(cmd.c.App.Writer, indent+"|-", tree.Name)
+	fmt.Fprintln(cmd.c.App.Writer, indent+"+-", tree.Type)
 
 	if last {
 		indent = indent + "  "

--- a/commands/version.go
+++ b/commands/version.go
@@ -55,5 +55,5 @@ func (cmd *Version) Run(scope scope.Scope, c *cli.Context) {
 	if nil != err {
 		error_handler.ErrorExit(err)
 	}
-	fmt.Println(version.Version)
+	fmt.Fprintln(c.App.Writer, version.Version)
 }

--- a/plugin/connection.go
+++ b/plugin/connection.go
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package plugin
+
+import (
+	"net/rpc"
+)
+
+type connection struct {
+	port string
+}
+
+func NewConnection(port string) *connection {
+	return &connection{
+		port: port,
+	}
+}
+
+func (c *connection) installPlugin(metadata PluginMetadata) bool {
+	client, err := rpc.Dial("tcp", "127.0.0.1:"+c.port)
+	if err != nil {
+		return false
+	}
+	defer client.Close()
+	var reply int
+	client.Call("RpcCommand.InstallPlugin", metadata, &reply)
+	return reply == 0
+}
+
+func (c *connection) CoreCommand(args ...string) []string {
+	client, err := rpc.Dial("tcp", "127.0.0.1:"+c.port)
+	if err != nil {
+		return []string{}
+	}
+	defer client.Close()
+	var cmdOutput []string
+	client.Call("RpcCommand.ExecuteCoreCommand", args, &cmdOutput)
+	return cmdOutput
+}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package plugin
+
+import (
+	"os"
+)
+
+type Plugin interface {
+	Run(connection Connection, args []string)
+	GetMetadata() PluginMetadata
+}
+
+type Connection interface {
+	CoreCommand(args ...string) []string
+}
+
+type PluginMetadata struct {
+	Name     string
+	Commands []Command
+}
+
+type Command struct {
+	Name         string
+	Alias        string
+	HelpText     string
+	UsageDetails Usage
+}
+
+type Usage struct {
+	Usage   string
+	Options map[string]string
+}
+
+func Start(cmd Plugin) {
+	conn := NewConnection(os.Args[1])
+	if len(os.Args) == 3 && os.Args[2] == "Install" {
+		conn.installPlugin(cmd.GetMetadata())
+	} else {
+		cmd.Run(conn, os.Args[2:])
+	}
+}

--- a/plugin/rpc_server.go
+++ b/plugin/rpc_server.go
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package plugin
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"github.com/apache/brooklyn-client/app"
+	"github.com/apache/brooklyn-client/command"
+	"github.com/apache/brooklyn-client/command_metadata"
+	"github.com/apache/brooklyn-client/command_runner"
+	"github.com/apache/brooklyn-client/scope"
+	"github.com/codegangsta/cli"
+	"net"
+	"net/rpc"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+type RpcServer struct {
+	listener    net.Listener
+	stopChannel chan struct{}
+	RpcCommand  *RpcCommand
+}
+
+type Factory interface {
+	GetByCmdName(cmdName string) (cmd command.Command, err error)
+	GetBySubCmdName(cmdName string, subCmdName string) (cmd command.Command, err error)
+	CommandMetadatas() []command_metadata.CommandMetadata
+}
+
+type Runner interface {
+	RunCmdByName(cmdName string, c *cli.Context) (err error)
+	RunSubCmdByName(cmdName string, subCommand string, c *cli.Context) (err error)
+}
+
+type RpcCommand struct {
+	PluginMetadata *PluginMetadata
+	commandFactory Factory
+}
+
+func NewRpcServer(commandFactory Factory) (*RpcServer, error) {
+	rpcServer := &RpcServer{
+		RpcCommand: &RpcCommand{
+			PluginMetadata: &PluginMetadata{},
+			commandFactory: commandFactory,
+		},
+	}
+	return rpcServer, nil
+}
+
+func (rpcServer *RpcServer) Start() error {
+	var err error
+
+	rpcServer.stopChannel = make(chan struct{})
+	rpc.Register(rpcServer.RpcCommand)
+	rpcServer.listener, err = net.Listen("tcp", "127.0.0.1:4567")
+	if err != nil {
+		return err
+	}
+	go func() {
+		for {
+			conn, err := rpcServer.listener.Accept()
+			if err == nil {
+				go rpc.ServeConn(conn)
+			} else {
+				select {
+				case <-rpcServer.stopChannel:
+					return
+				default:
+					fmt.Println(err)
+				}
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (cli *RpcServer) Stop() {
+	close(cli.stopChannel)
+	cli.listener.Close()
+}
+
+func (cli *RpcServer) Port() string {
+	return strconv.Itoa(cli.listener.Addr().(*net.TCPAddr).Port)
+}
+
+func (cmd *RpcCommand) InstallPlugin(pluginMetadata PluginMetadata, retVal *bool) error {
+	cmd.PluginMetadata = &pluginMetadata
+	*retVal = true
+	return nil
+}
+
+func (cmd *RpcCommand) ExecuteCoreCommand(args []string, retVal *[]string) error {
+	args2, scope := scope.ScopeArguments(args)
+	cmdRunner := command_runner.NewRunner(scope, cmd.commandFactory)
+	metadatas := cmd.commandFactory.CommandMetadatas()
+	theApp := app.NewApp(filepath.Base(args[0]), cmdRunner, metadatas...)
+	var buf bytes.Buffer
+	f := bufio.NewWriter(&buf)
+	theApp.Writer = f
+	theApp.Run(args2)
+	f.Flush()
+	*retVal = strings.Split(buf.String(), "\n")
+	return nil
+}

--- a/terminal/table.go
+++ b/terminal/table.go
@@ -20,6 +20,7 @@ package terminal
 
 import (
 	"fmt"
+	"github.com/codegangsta/cli"
 	"strings"
 	"unicode/utf8"
 )
@@ -34,12 +35,14 @@ type PrintableTable struct {
 	headerPrinted bool
 	maxSizes      []int
 	rows          [][]string
+	c             *cli.Context
 }
 
-func NewTable(headers []string) Table {
+func NewTable(c *cli.Context, headers []string) Table {
 	return &PrintableTable{
 		headers:  headers,
 		maxSizes: make([]int, len(headers)),
+		c:        c,
 	}
 }
 
@@ -78,7 +81,7 @@ func (t *PrintableTable) printHeader() {
 	for col, value := range t.headers {
 		output = output + t.cellValue(col, value)
 	}
-	fmt.Println(output)
+	fmt.Fprintln(t.c.App.Writer, output)
 }
 
 func (t *PrintableTable) printRow(row []string) {
@@ -90,7 +93,7 @@ func (t *PrintableTable) printRow(row []string) {
 
 		output = output + t.cellValue(columnIndex, value)
 	}
-	fmt.Printf("%s\n", output)
+	fmt.Fprintf(t.c.App.Writer, "%s\n", output)
 }
 
 func (t *PrintableTable) cellValue(col int, value string) string {


### PR DESCRIPTION
A sample plugin would look like this:

``` go
package main

import (
    "github.com/apache/brooklyn-client/plugin"
    "fmt"
    "strings"
)

type SamplePlugin struct {}

func (c *SamplePlugin) Run(plugin plugin.Connection, args []string)  {
    if args[0] == "sample-command" {
        fmt.Println("Running the sample plugin")
        out := plugin.CoreCommand(strings.Split("br apps", " ")...)
        for i, e := range out {
            fmt.Printf("%v %v\n", i, e)
        }
    }
}

func (c *SamplePlugin) GetMetadata() plugin.PluginMetadata {
    return plugin.PluginMetadata{
        Name: "SamplePlugin",
        Commands: []plugin.Command{
            plugin.Command{
                Name: "sample-command",
                Alias: "sc",
                HelpText: "A Sample Command",
                UsageDetails: plugin.Usage{
                    Usage: "sample-command\n br sample-command",
                },
            },
        },
    }
}

func main() {
    plugin.Start(new(SamplePlugin))
}
```

which should be compiled with `go build`.  The resulting artifact should be installed with `br install-plugin <artifact-location>`, which will copy the artifact to either `$HOME` or `$BRCLI_HOME/plugins` if it is set; this location is required to on `$PATH` for the plugin to be executed.    
