### PR TITLE
[BROOKLYN-280] add --skipSslChecks flag to work with self-signed certs

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -39,7 +39,7 @@ var appConfig = configDefaults{
 	Name:     os.Args[0],
 	HelpName: os.Args[0],
 	Usage:    "A Brooklyn command line client application",
-	Version:  "0.9.0",
+	Version:  "0.10.0-SNAPSHOT",
 }
 
 func NewApp(baseName string, cmdRunner command_runner.Runner, metadatas ...command_metadata.CommandMetadata) (app *cli.App) {
@@ -51,6 +51,13 @@ func NewApp(baseName string, cmdRunner command_runner.Runner, metadatas ...comma
 	app.HelpName = appConfig.HelpName
 	app.Usage = appConfig.Usage
 	app.Version = appConfig.Version
+
+	app.Flags = []cli.Flag{
+		cli.BoolFlag{
+			Name:  "skipSslChecks",
+			Usage: "Skip verification of server's certificate chain and hostname (for use with self-signed certs)",
+		},
+	}
 
 	app.Commands = []cli.Command{}
 

--- a/app/app.go
+++ b/app/app.go
@@ -39,7 +39,7 @@ var appConfig = configDefaults{
 	Name:     os.Args[0],
 	HelpName: os.Args[0],
 	Usage:    "A Brooklyn command line client application",
-	Version:  "0.10.0-SNAPSHOT",
+	Version:  "0.10.0-SNAPSHOT",  // BROOKLYN_VERSION
 }
 
 func NewApp(baseName string, cmdRunner command_runner.Runner, metadatas ...command_metadata.CommandMetadata) (app *cli.App) {

--- a/br/brooklyn.go
+++ b/br/brooklyn.go
@@ -30,8 +30,9 @@ import (
 	"path/filepath"
 )
 
-func getNetworkCredentialsFromConfig(yamlMap map[string]interface{}) (string, string, string) {
+func getNetworkCredentialsFromConfig(yamlMap map[string]interface{}) (string, string, string, bool) {
 	var target, username, password string
+	var skipSslChecks bool
 	target, found := yamlMap["target"].(string)
 	if found {
 		auth, found := yamlMap["auth"].(map[string]interface{})
@@ -42,15 +43,16 @@ func getNetworkCredentialsFromConfig(yamlMap map[string]interface{}) (string, st
 				password, found = creds["password"].(string)
 			}
 		}
+		skipSslChecks, _ = yamlMap["skipSslChecks"].(bool)
 	}
-	return target, username, password
+	return target, username, password, skipSslChecks
 }
 
 func main() {
 	config := io.GetConfig()
-	target, username, password := getNetworkCredentialsFromConfig(config.Map)
+	target, username, password, skipSslChecks := getNetworkCredentialsFromConfig(config.Map)
 	//target, username, password := "http://192.168.50.101:8081", "brooklyn", "Sns4Hh9j7l"
-	network := net.NewNetwork(target, username, password)
+	network := net.NewNetwork(target, username, password, skipSslChecks)
 	cmdFactory := command_factory.NewFactory(network, config)
 
 	args, scope := scope.ScopeArguments(os.Args)

--- a/commands/login.go
+++ b/commands/login.go
@@ -61,6 +61,7 @@ func (cmd *Login) Run(scope scope.Scope, c *cli.Context) {
 	cmd.network.BrooklynUrl = c.Args().Get(0)
 	cmd.network.BrooklynUser = c.Args().Get(1)
 	cmd.network.BrooklynPass = c.Args().Get(2)
+	cmd.network.SkipSslChecks = c.GlobalBool("skipSslChecks")
 
 	if err := net.VerifyLoginURL(cmd.network); err != nil {
 		error_handler.ErrorExit(err)
@@ -101,6 +102,7 @@ func (cmd *Login) Run(scope scope.Scope, c *cli.Context) {
 	}
 
 	cmd.config.Map["target"] = cmd.network.BrooklynUrl
+	cmd.config.Map["skipSslChecks"] = cmd.network.SkipSslChecks
 	cmd.config.Write()
 
 	loginVersion, err := version.Version(cmd.network)

--- a/net/net.go
+++ b/net/net.go
@@ -30,19 +30,22 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"crypto/tls"
 )
 
 type Network struct {
 	BrooklynUrl  string
 	BrooklynUser string
 	BrooklynPass string
+	SkipSslChecks bool
 }
 
-func NewNetwork(brooklynUrl, brooklynUser, brooklynPass string) (net *Network) {
+func NewNetwork(brooklynUrl, brooklynUser, brooklynPass string, skipSslChecks bool) (net *Network) {
 	net = new(Network)
 	net.BrooklynUrl = brooklynUrl
 	net.BrooklynUser = brooklynUser
 	net.BrooklynPass = brooklynPass
+	net.SkipSslChecks = skipSslChecks
 	return
 }
 
@@ -93,7 +96,10 @@ func makeError(resp *http.Response, code int, body []byte) error {
 }
 
 func (net *Network) SendRequest(req *http.Request) ([]byte, error) {
-	client := &http.Client{}
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: net.SkipSslChecks},
+	}
+	client := &http.Client{Transport: tr}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- defaults to `false`, ie existing behaviour
- setting the flag `--skipSslChecks` disables certificate chain and hostname verification (see `InsecureSkipVerify` in https://golang.org/pkg/crypto/tls/)
- persisted to `~/.brooklyn_cli`
- also bumped version to `0.10.0-SNAPSHOT`

```
bash-4.3$ br login https://10.10.10.100:8443/ admin password
Get https://10.10.10.100:8443/v1/server/version: x509: certificate signed by unknown authority
bash-4.3$ br app
Get https://10.10.10.100:8443/v1/applications: x509: certificate signed by unknown authority

bash-4.3$ br --skipSslChecks login https://10.10.10.100:8443/ admin password
Connected to Brooklyn version 0.10.0-20160513.2042 at https://10.10.10.100:8443
bash-4.3$ br app
Id   Name   Status   Location
```
*Note*: I'd no apps running on this system so the empty table is ok, catalog returns as expected.

```json
{
    "auth": {
        "https://10.10.10.100:8443": {
            "password": "password",
            "username": "admin"
        }
    },
    "skipSslChecks": true,
    "target": "https://10.10.10.100:8443"
}
```