### PR TITLE
Updated resteasy version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <logback.version>1.0.7</logback.version>
         <slf4j.version>1.6.6</slf4j.version>  <!-- used for java.util.logging jul-to-slf4j interception -->
         <guava.version>16.0.1</guava.version>
-        <resteasy.version>3.0.14.Final</resteasy.version>
+        <resteasy.version>3.0.19.Final</resteasy.version>
         <cxf.version>3.1.4</cxf.version>
         <httpclient.version>4.4.1</httpclient.version>
         <jsr305.version>2.0.1</jsr305.version>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <logback.version>1.0.7</logback.version>
         <slf4j.version>1.6.6</slf4j.version>  <!-- used for java.util.logging jul-to-slf4j interception -->
         <guava.version>16.0.1</guava.version>
-        <resteasy.version>3.0.8.Final</resteasy.version>
+        <resteasy.version>3.0.14.Final</resteasy.version>
         <cxf.version>3.1.4</cxf.version>
         <httpclient.version>4.4.1</httpclient.version>
         <jsr305.version>2.0.1</jsr305.version>


### PR DESCRIPTION
This is successor to [this PR](https://github.com/apache/brooklyn-server/pull/317).
After the rest client was moved to brooklyn-client in [this PR](https://github.com/apache/brooklyn-client/pull/25) two new PRs had to be created, one for brooklyn-server and one for brooklyn-client.

Please merge [this PR](https://github.com/apache/brooklyn-server/pull/339) at the same time.

This PR updates resteasy to 3.0.14.Final.