### PR TITLE
Experimental addition of 'catalog show'.

### DIFF
--- a/cli/api/catalog/catalog.go
+++ b/cli/api/catalog/catalog.go
@@ -89,7 +89,7 @@ func GetPolicy(network *net.Network, policyId string) (models.CatalogItemSummary
 }
 
 func GetPolicyWithVersion(network *net.Network, policyId, version string) (models.CatalogItemSummary, error) {
-	url := fmt.Sprintf("/v1/catalog/policies/%s/%s", policyId)
+	url := fmt.Sprintf("/v1/catalog/policies/%s/%s", policyId, version)
 	var catalogItem models.CatalogItemSummary
 	body, err := network.SendGetRequest(url)
 	if err != nil {
@@ -148,9 +148,9 @@ func DeleteLocationWithVersion(network *net.Network, locationId, version string)
 	return string(body), nil
 }
 
-func Policies(network *net.Network) ([]models.CatalogPolicySummary, error) {
+func Policies(network *net.Network) ([]models.CatalogItemSummary, error) {
 	url := "/v1/catalog/policies?allVersions"
-	var policies []models.CatalogPolicySummary
+	var policies []models.CatalogItemSummary
 	body, err := network.SendGetRequest(url)
 	if err != nil {
 		return policies, err
@@ -159,9 +159,9 @@ func Policies(network *net.Network) ([]models.CatalogPolicySummary, error) {
 	return policies, err
 }
 
-func Locations(network *net.Network) ([]models.CatalogLocationSummary, error) {
+func Locations(network *net.Network) ([]models.CatalogItemSummary, error) {
 	url := "/v1/catalog/locations?allVersions=true"
-	var catalogLocations []models.CatalogLocationSummary
+	var catalogLocations []models.CatalogItemSummary
 	body, err := network.SendGetRequest(url)
 	if err != nil {
 		return catalogLocations, err
@@ -190,9 +190,20 @@ func Reset(network *net.Network) (string, error) {
 	return string(body), nil
 }
 
-func GetLocationWithVersion(network *net.Network, locationId, version string) (models.CatalogLocationSummary, error) {
+func GetLocation(network *net.Network, locationId string) (models.CatalogItemSummary, error) {
+	url := fmt.Sprintf("/v1/catalog/locations/%s", locationId)
+	var catalogLocation models.CatalogItemSummary
+	body, err := network.SendGetRequest(url)
+	if err != nil {
+		return catalogLocation, err
+	}
+	err = json.Unmarshal(body, &catalogLocation)
+	return catalogLocation, err
+}
+
+func GetLocationWithVersion(network *net.Network, locationId, version string) (models.CatalogItemSummary, error) {
 	url := fmt.Sprintf("/v1/catalog/locations/%s/%s", locationId, version)
-	var catalogLocation models.CatalogLocationSummary
+	var catalogLocation models.CatalogItemSummary
 	body, err := network.SendGetRequest(url)
 	if err != nil {
 		return catalogLocation, err
@@ -232,13 +243,3 @@ func Catalog(network *net.Network) ([]models.CatalogItemSummary, error) {
 	return applications, err
 }
 
-func GetLocation(network *net.Network, locationId string) (models.CatalogLocationSummary, error) {
-	url := fmt.Sprintf("/v1/catalog/locations/%s", locationId)
-	var catalogLocation models.CatalogLocationSummary
-	body, err := network.SendGetRequest(url)
-	if err != nil {
-		return catalogLocation, err
-	}
-	err = json.Unmarshal(body, &catalogLocation)
-	return catalogLocation, err
-}

--- a/cli/app/app.go
+++ b/cli/app/app.go
@@ -56,6 +56,10 @@ func NewApp(baseName string, cmdRunner command_runner.Runner, metadatas ...comma
 			Name:  "skipSslChecks",
 			Usage: "Skip verification of server's certificate chain and hostname (for use with self-signed certs)",
 		},
+		cli.StringFlag{
+			Name:  "json, j",
+			Usage: "Render value as json with json path selector as described at https://github.com/NodePrime/jsonpath. (Experimental, not supported on all commands at present) ",
+		},
 	}
 
 	app.Commands = []cli.Command{}

--- a/cli/commands/catalog-list.go
+++ b/cli/commands/catalog-list.go
@@ -109,7 +109,7 @@ func (cmd *CatalogList) listLocations(c *cli.Context) ([]models.IdentityDetails,
 	}
 	result := make([]models.IdentityDetails, len(locations))
 	for i, location := range locations {
-		result[i] = location.CatalogItemSummary.IdentityDetails
+		result[i] = location.IdentityDetails
 	}
 	return result, nil
 }

--- a/cli/commands/catalog-show.go
+++ b/cli/commands/catalog-show.go
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package commands
+
+import (
+	"github.com/apache/brooklyn-client/cli/api/catalog"
+	"github.com/apache/brooklyn-client/cli/command_metadata"
+	"github.com/apache/brooklyn-client/cli/error_handler"
+	"github.com/apache/brooklyn-client/cli/net"
+	"github.com/apache/brooklyn-client/cli/scope"
+	"github.com/urfave/cli"
+	"github.com/apache/brooklyn-client/cli/models"
+	"errors"
+	"strings"
+)
+
+type CatalogShow struct {
+	network *net.Network
+}
+
+func NewCatalogShow(network *net.Network) (cmd *CatalogShow) {
+	cmd = new(CatalogShow)
+	cmd.network = network
+	return
+}
+
+const showCommandName = "show"
+
+func (cmd *CatalogShow) Metadata() command_metadata.CommandMetadata {
+	return command_metadata.CommandMetadata{
+		Name:        showCommandName,
+		Description: "Show a catalog item",
+		Usage:       "BROOKLYN_NAME catalog " + showCommandName + " " + catalogItemTypesUsage + " ITEM",
+	}
+}
+
+func (cmd *CatalogShow) Run(scope scope.Scope, c *cli.Context) {
+	if err := net.VerifyLoginURL(cmd.network); err != nil {
+		error_handler.ErrorExit(err)
+	}
+	err := cmd.show(c)
+	if nil != err {
+		error_handler.ErrorExit(err)
+	}
+}
+
+func (cmd *CatalogShow) show(c *cli.Context) (error) {
+	if len(c.Args()) != 2 {
+		return errors.New(c.App.Name + " " + showCommandName + catalogItemTypesUsage + " ITEM[:VERSION]")
+	}
+	catalogType, err := GetCatalogType(c)
+	if  err != nil {
+		return err
+	}
+	item := c.Args().Get(1)
+	var version string
+	if strings.Contains(item, ":") {
+		itemVersion := strings.Split(item, ":")
+		item = itemVersion[0]
+		version = itemVersion[1]
+	}
+	switch catalogType {
+	case ApplicationsItemType:
+		return cmd.showCatalogApplication(c, item, version)
+	case EntitiesItemType:
+		return cmd.showCatalogEntity(c, item, version)
+	case LocationsItemType:
+		return cmd.showCatalogLocation(c, item, version)
+	case PoliciesItemType:
+		return cmd.showPolicy(c, item, version)
+	}
+	return errors.New("Unrecognised argument")
+}
+
+func (cmd *CatalogShow) showPolicy(c *cli.Context, item string, version string) (error) {
+	var summary models.CatalogItemSummary
+	var err error
+	if version == "" {
+		summary, err = catalog.GetPolicy(cmd.network, item)
+	} else {
+		summary, err = catalog.GetPolicyWithVersion(cmd.network, item, version)
+	}
+	if err != nil {
+		return err
+	}
+
+	return summary.Display(c)
+}
+
+func (cmd *CatalogShow) showCatalogLocation(c *cli.Context, item string, version string) (error) {
+	var summary models.CatalogItemSummary
+	var err error
+	if version == "" {
+		summary, err = catalog.GetLocation(cmd.network, item)
+	} else {
+		summary, err = catalog.GetLocationWithVersion(cmd.network, item, version)
+	}
+	if err != nil {
+		return err
+	}
+	return summary.Display(c)
+}
+
+func (cmd *CatalogShow) showCatalogEntity(c *cli.Context, item string, version string) (error) {
+	var summary models.CatalogEntitySummary
+	var err error
+	if version == "" {
+		summary, err = catalog.GetEntity(cmd.network, item)
+	} else {
+		summary, err = catalog.GetEntityWithVersion(cmd.network, item, version)
+	}
+	if err != nil {
+		return err
+	}
+	return summary.Display(c)
+}
+
+func (cmd *CatalogShow) showCatalogApplication(c *cli.Context, item string, version string) (error) {
+	var summary models.CatalogEntitySummary
+	var err error
+	if version == "" {
+		summary, err = catalog.GetApplication(cmd.network, item)
+	} else {
+		summary, err = catalog.GetApplicationWithVersion(cmd.network, item, version)
+	}
+	if err != nil {
+		return err
+	}
+
+	return summary.Display(c)
+
+}

--- a/cli/commands/catalog.go
+++ b/cli/commands/catalog.go
@@ -39,6 +39,7 @@ func NewCatalog(network *net.Network) (cmd *Catalog) {
 	cmd = new(Catalog)
 	cmd.network = network
 	cmd.catalogCommands = map[string]command.Command {
+		ShowCatalogCommand: NewCatalogShow(cmd.network),
 		ListCatalogCommand: NewCatalogList(cmd.network),
 		AddCatalogCommand: NewCatalogAdd(cmd.network),
 		DeleteCatalogCommand: NewDeleteCatalogItem(cmd.network),
@@ -46,16 +47,18 @@ func NewCatalog(network *net.Network) (cmd *Catalog) {
 	return
 }
 
+const ShowCatalogCommand = "show"
 const ListCatalogCommand = "list"
 const AddCatalogCommand = "add"
 const DeleteCatalogCommand = "delete"
 
 var catalogCommands = []string{
+	ShowCatalogCommand,
 	ListCatalogCommand,
 	AddCatalogCommand,
 	DeleteCatalogCommand,
 }
-var catalogCommandsUsage = "list TYPE | add FILE/URL | delete TYPE ID:VERSION"
+var catalogCommandsUsage = "list TYPE | add FILE/URL | delete TYPE ID:VERSION | show ITEM"
 
 type CatalogItemType int
 const  (
@@ -96,6 +99,7 @@ func (cmd *Catalog) Metadata() command_metadata.CommandMetadata {
 		Usage:       "BROOKLYN_NAME catalog (" + catalogCommandsUsage + ")",
 		Flags:       []cli.Flag{},
 		Operands:    []command_metadata.CommandMetadata{
+			cmd.SubCommand(ShowCatalogCommand).Metadata(),
 			cmd.SubCommand(ListCatalogCommand).Metadata(),
 			cmd.SubCommand(AddCatalogCommand).Metadata(),
 			cmd.SubCommand(DeleteCatalogCommand).Metadata(),

--- a/cli/glide.lock
+++ b/cli/glide.lock
@@ -1,10 +1,14 @@
-hash: 1d87d5643857ae47cd40cc29e7b9b813198980c84b3491376b3561c467e37994
-updated: 2016-06-02T21:50:02.953614402+01:00
+hash: b5e09364283348512d5174937c662382a47e3d5e93f0f707aada9c2520d861e3
+updated: 2016-11-01T17:46:14.530067679Z
 imports:
+- name: github.com/NodePrime/jsonpath
+  version: 84403ded544328c99be3472727667179eef23a91
+  subpackages:
+  - cli/jsonpath
 - name: github.com/urfave/cli
   version: 5db74198dee1cfe60cf06a611d03a420361baad6
 - name: golang.org/x/crypto
   version: 1f22c0103821b9390939b6776727195525381532
   subpackages:
   - ssh/terminal
-devImports: []
+testImports: []

--- a/cli/glide.yaml
+++ b/cli/glide.yaml
@@ -1,6 +1,7 @@
 package: github.com/apache/brooklyn-client
 import:
 - package: github.com/urfave/cli
+- package: github.com/NodePrime/jsonpath/cli/jsonpath
 - package: golang.org/x/crypto
   subpackages:
   - ssh/terminal

--- a/cli/models/catalog.go
+++ b/cli/models/catalog.go
@@ -18,6 +18,16 @@
  */
 package models
 
+import (
+	"github.com/apache/brooklyn-client/cli/terminal"
+	"bytes"
+	"strconv"
+	"fmt"
+	"encoding/json"
+	"github.com/urfave/cli"
+	"github.com/NodePrime/jsonpath"
+)
+
 type IdentityDetails struct {
 	Id           string                 `json:"id"`
 	Name         string                 `json:"name"`
@@ -31,28 +41,147 @@ type CatalogItemSummary struct {
 	JavaType     string                 `json:"javaType"`
 	PlanYaml     string                 `json:"planYaml"`
 	Deprecated   bool                   `json:"deprecated"`
+	Config       []ConfigSummary        `json:"config"`
+	Tags         []interface{}          `json:"tags"`
 	Links        map[string]interface{} `json:"links"`
 	Type         string                 `json:"type"`
 }
 
-type CatalogPolicySummary struct {
-	IdentityDetails
-	javaType     string         `json:"javaType"`
-	planYaml     string         `json:"planYaml"`
-	iconUrl      string         `json:"iconUrl"`
-	deprecated   bool           `json:"deprecated"`
-	links        map[string]URI `json:"links"`
-}
-
-
-type CatalogLocationSummary struct {
-	CatalogItemSummary
-	IconUrl     string                 `json:"iconUrl"`
-}
-
 type CatalogEntitySummary struct {
 	CatalogItemSummary
-	Config       []ConfigSummary        `json:"config"`
-	Effectors    []EffectorSummary      `json:"effectors"`
-	Sensors      []SensorSummary        `json:"sensors"`
+	IconUrl      string                `json:"iconUrl"`
+	Effectors    []EffectorSummary     `json:"effectors"`
+	Sensors      []SensorSummary       `json:"sensors"`
+}
+
+func createTableWithIdentityDetails(item IdentityDetails) (terminal.Table) {
+	table := terminal.NewTable([]string{"Id:", item.Id})
+	table.Add("Version:", item.Version)
+	table.Add("Name:", item.Name)
+	table.Add("Symbolic Name:", item.SymbolicName)
+	table.Add("Description:", item.Description)
+	return table
+}
+
+func (summary *CatalogItemSummary) Display(c *cli.Context) (err error) {
+
+	if json := c.GlobalString("json") ; json != "" {
+		displayAsJson(summary, json)
+	} else {
+		summary.displayAsTable()
+	}
+	return err
+}
+
+
+func (summary *CatalogEntitySummary) Display(c *cli.Context) (err error) {
+
+	if json := c.GlobalString("json") ; json != "" {
+		displayAsJson(summary, json)
+	} else {
+		summary.displayAsTable()
+	}
+	return err
+}
+
+
+
+func (summary *CatalogItemSummary) displayAsTable() (err error){
+
+	table := createTableWithIdentityDetails(summary.IdentityDetails)
+	if summary.Deprecated {
+		table.Add("Deprecated:", "true")
+	}
+	table.Add("Java Type:", summary.JavaType)
+	table.Print()
+	return err
+}
+
+func (summary *CatalogEntitySummary) displayAsTable() (err error){
+
+	table := createTableWithIdentityDetails(summary.IdentityDetails)
+	if summary.Deprecated {
+		table.Add("Deprecated:", "true")
+	}
+	table.Add("Java Type:", summary.JavaType)
+	table.Add("Icon URL:", summary.IconUrl)
+
+	for c, conf := range summary.Config {
+		if c == 0 {
+			table.Add("", "") // helps distinguish entries from one another
+			table.Add("Config:", "")
+		}
+		table.Add("Name:", conf.Name)
+		table.Add("Type:", conf.Type)
+		table.Add("Description:", conf.Description)
+		table.Add("Default Value:", fmt.Sprintf("%v", conf.DefaultValue))
+		table.Add("Reconfigurable:", strconv.FormatBool(conf.Reconfigurable))
+		table.Add("Label:", conf.Label)
+		table.Add("Priority:", strconv.FormatFloat(conf.Priority, 'f', -1, 64))
+		table.Add("Pinned:", strconv.FormatBool(conf.Pinned))
+
+		if len(conf.PossibleValues) > 0 {
+			var values bytes.Buffer
+			for i, pv := range conf.PossibleValues {
+				if i > 0 {
+					values.WriteString(", ")
+				}
+				values.WriteString(pv["value"])
+				if pv["value"] != pv["description"] {
+					values.WriteString(" (" + pv["description"] + ")")
+				}
+			}
+			table.Add("Possible Values:", values.String())
+		}
+		table.Add("", "") // helps distinguish entries from one another
+	}
+
+	for t, tag := range summary.Tags {
+		if t == 0 {
+			table.Add("", "") // helps distinguish entries from one another
+			table.Add("Tags:", "")
+		}
+		if asJson, erj := json.Marshal(tag); nil == erj {
+			table.Add("tag:", string(asJson))
+		} else {
+			table.Add("tag:", fmt.Sprintf("%v", tag))
+		}
+	}
+
+	table.Print()
+	return err
+}
+
+
+
+func displayAsJson(v interface{}, jsonPath string) (err error) {
+	marshalled, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	// a convenient special case
+	if "$" == jsonPath {
+		fmt.Printf("%s", string(marshalled))
+		return nil
+	}
+
+	paths, err := jsonpath.ParsePaths(jsonPath)
+	if err != nil {
+		return err
+	}
+	eval, err := jsonpath.EvalPathsInBytes(marshalled, paths)
+	if err != nil {
+		return err
+	}
+	for {
+		if result, ok := eval.Next(); ok {
+			fmt.Print(result.Pretty(false)) // true -> show keys in pretty string
+		} else {
+			break
+		}
+	}
+	if eval.Error != nil {
+		return eval.Error
+	}
+	return nil
 }

--- a/cli/models/config.go
+++ b/cli/models/config.go
@@ -27,5 +27,6 @@ type ConfigSummary struct {
 	Links          map[string]URI      `json:"links"`
 	Label          string              `json:"label"`
 	Priority       float64             `json:"priority"`
+	Pinned         bool                `json:"pinned"`
 	Type           string              `json:"type"`
 }


### PR DESCRIPTION
Examples:

	br catalog show
	br catalog show ( application | entity | location | policy ) ITEM[:VERSION]

apps:

    br catalog show app TomcatServer
    Id:               | TomcatServer:4.1.0-SNAPSHOT
    Version:          | 4.1.0-SNAPSHOT
    Name:             | Tomcat Server
    ...etc.

specific version:

    br catalog show app TomcatServer:4.1.0-SNAPSHOT
    Id:               | TomcatServer:4.1.0-SNAPSHOT
    Version:          | 4.1.0-SNAPSHOT
    Name:             | Tomcat Server
    ...

entities:

    br catalog show ent docker-engine | head -3
    Id:                | docker-engine:2.1.0-SNAPSHOT
    Version:           | 2.1.0-SNAPSHOT
    Name:              | Docker Engine
    ...

policies:

    br catalog show pol org.apache.brooklyn.policy.ha.ServiceReplacer
    Id:              | org.apache.brooklyn.policy.ha.ServiceReplacer:4.1.0-SNAPSHOT
    Version:         | 4.1.0-SNAPSHOT
    Name:            | Service Replacer
    Symbolic Name:   | org.apache.brooklyn.policy.ha.ServiceReplacer
    Description:     | HA policy for replacing a failed member of a group
    Java Type:       |

Experimental: render as JSON. Some work required...

Special case: render the whole JSON with jsonpath value `$`:

    br -j '$' catalog show ent docker-engine
    {"id":"docker-engine:2.1.0-SNAPSHOT","name":"Docker Engine",...

General case: give a JSON path expression following the syntax of https://github.com/NodePrime/jsonpath:

    br -j '$.config[*].label+' catalog show ent docker-engine
    "Docker Package"
    "Docker Version"
    "Docker Repository URL"
    "Docker GPG Key URL"
    "Docker Additional Options"
    "Image Pre-install"
    "archive.nameFormat"