### PR TITLE
Exclude cli/.glide/* (cache) from rat + git

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,2 +1,3 @@
 temp_test
 vendor/
+.glide/

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -101,6 +101,7 @@
                     <excludes combine.children="append">
                         <exclude>vendor/**</exclude>
                         <exclude>glide.*</exclude>
+                        <exclude>.glide/**</exclude>
                     </excludes>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Without this, the build fails for me: the many files created in cli/.glide/cache fail the rat check.