### PR TITLE
Set ContentType header when adding .yaml and .bom files to the catalog

### DIFF
--- a/cli/api/catalog/catalog.go
+++ b/cli/api/catalog/catalog.go
@@ -275,6 +275,8 @@ func AddCatalog(network *net.Network, resource string) (*models.CatalogBundleAdd
 			} else if lowercaseExtension == ".jar" {
 				contentType = "application/x-jar"
 				urlString = urlStringWithDetail
+			} else if lowercaseExtension == ".yaml" || lowercaseExtension == ".bom" {
+				contentType = "application/x-yaml"
 			}
 		}
 


### PR DESCRIPTION
Using application/x-yaml saves the Brooklyn server the hassle of guessing. At the moment it's too smart for its own good and gives useless errors about zipfiles when there are errors in yaml files, e.g. when trying to add yaml containing an undefined alias.

Before:
```
$ br catalog add mybp.bom
Server error (400): Bundle BasicManagedBundle{symbolicName=null, version=null, url=n
ull} failed preparation: Unable to read /tmp/brooklyn-bundle-transient-null-86366849
75390229868.zip when looking for manifest: ZipException: error in opening zip file
```
After:
```
$ br catalog add mybp.bom
Server error (400): ComposerException: found undefined alias doesntexist
 in 'reader', line 23, column 15:
            name: *doesntexist
```
I'll look to improve the feedback from Brooklyn's guessing endpoint too. 