### PR TITLE
Invoke effector: support timeout

### DIFF
--- a/cli/api/entity_effectors/effectors.go
+++ b/cli/api/entity_effectors/effectors.go
@@ -42,11 +42,14 @@ func EffectorList(network *net.Network, application, entity string) ([]models.Ef
 	return effectorList, err
 }
 
-func TriggerEffector(network *net.Network, application, entity, effector string, params []string, args []string) (string, error) {
+func TriggerEffector(network *net.Network, application, entity, effector string, timeout string, params []string, args []string) (string, error) {
 	if len(params) != len(args) {
 		return "", errors.New(strings.Join([]string{"Parameters not supplied:", strings.Join(params, ", ")}, " "))
 	}
 	path := fmt.Sprintf("/v1/applications/%s/entities/%s/effectors/%s", application, entity, effector)
+	if (timeout != "") {
+		path = fmt.Sprintf("%s?timeout=%s", path, url.QueryEscape(timeout))
+	}
 	data := url.Values{}
 	for i := range params {
 		data.Set(params[i], args[i])

--- a/cli/commands/invoke.go
+++ b/cli/commands/invoke.go
@@ -77,13 +77,17 @@ var paramFlags = []cli.Flag{
 		Usage: "Parameter and value separated by '=', e.g. -P x=y. If the parameter value is complex or multi-" +
 		       "lined it may be provided in a file and referenced as: '@<file>', e.g. -P x=@/path/to/file.",
 	},
+	cli.StringFlag{
+		Name:  "timeout",
+		Usage: "Timeout for waiting for effector (e.g. '1s' for one second, '0' for forever); defaults to forever.",
+	},
 }
 
 func (cmd *Invoke) Metadata() command_metadata.CommandMetadata {
 	return command_metadata.CommandMetadata{
 		Name:        "invoke",
 		Description: "Invoke an effector of an application and entity",
-		Usage:       "BROOKLYN_NAME EFF-SCOPE invoke [ parameter-options ]",
+		Usage:       "BROOKLYN_NAME EFF-SCOPE invoke [ --timeout <val> ] [ parameter-options ]",
 		Flags:       paramFlags,
 	}
 }
@@ -119,8 +123,9 @@ func (cmd *Invoke) Run(scope scope.Scope, c *cli.Context) {
 	if err := net.VerifyLoginURL(cmd.network); err != nil {
 		error_handler.ErrorExit(err)
 	}
+	timeout := c.String("timeout")
 	parms := c.StringSlice("param")
-	invoke(cmd.network, scope.Application, scope.Entity, scope.Effector, parms)
+	invoke(cmd.network, scope.Application, scope.Entity, scope.Effector, timeout, parms)
 }
 
 const stopEffector = "stop"
@@ -129,8 +134,9 @@ func (cmd *Stop) Run(scope scope.Scope, c *cli.Context) {
 	if err := net.VerifyLoginURL(cmd.network); err != nil {
 		error_handler.ErrorExit(err)
 	}
+	timeout := c.String("timeout")
 	parms := c.StringSlice("param")
-	invoke(cmd.network, scope.Application, scope.Entity, stopEffector, parms)
+	invoke(cmd.network, scope.Application, scope.Entity, stopEffector, timeout, parms)
 }
 
 const startEffector = "start"
@@ -139,8 +145,9 @@ func (cmd *Start) Run(scope scope.Scope, c *cli.Context) {
 	if err := net.VerifyLoginURL(cmd.network); err != nil {
 		error_handler.ErrorExit(err)
 	}
+	timeout := c.String("timeout")
 	parms := c.StringSlice("param")
-	invoke(cmd.network, scope.Application, scope.Entity, startEffector, parms)
+	invoke(cmd.network, scope.Application, scope.Entity, startEffector, timeout, parms)
 }
 
 const restartEffector = "restart"
@@ -149,13 +156,14 @@ func (cmd *Restart) Run(scope scope.Scope, c *cli.Context) {
 	if err := net.VerifyLoginURL(cmd.network); err != nil {
 		error_handler.ErrorExit(err)
 	}
+	timeout := c.String("timeout")
 	parms := c.StringSlice("param")
-	invoke(cmd.network, scope.Application, scope.Entity, restartEffector, parms)
+	invoke(cmd.network, scope.Application, scope.Entity, restartEffector, timeout, parms)
 }
 
-func invoke(network *net.Network, application, entity, effector string, parms []string) {
+func invoke(network *net.Network, application, entity, effector string, timeout string, parms []string) {
 	names, vals, err := extractParams(parms)
-	result, err := entity_effectors.TriggerEffector(network, application, entity, effector, names, vals)
+	result, err := entity_effectors.TriggerEffector(network, application, entity, effector, timeout, names, vals)
 	if nil != err {
 		error_handler.ErrorExit(err)
 	} else {


### PR DESCRIPTION
Passes the timeout arg (if supplied) when making the REST api call to Brooklyn. The response from this is written to stdout.

If it times out, the REST api still gives back a 202 response code with a json payload describing the executing task. The `br` tool simply writes that to stdout. For example:

```
cli/target/bin/darwin.amd64/br app rbfvau9i75 effector stop invoke --timeout 1ms

{"id":"kpML04c1","displayName":"stop","description":"Invoking effector stop on server @ localhost with parameters {}","entityId":"rbfvau9i75","entityDisplayName":"server @ localhost","tags":["EFFECTOR",{"entityId":"rbfvau9i75","effectorName":"stop"},{"entitlementContext":{"user":"<snip>","sourceIp":"0:0:0:0:0:0:0:1","requestUri":"/v1/applications/rbfvau9i75/entities/rbfvau9i75/effectors/stop","requestUniqueIdentifier":"rjuSuB"}},{"type":"org.apache.brooklyn.api.mgmt.ManagementContext"},{"wrappingType":"targetEntity","entity":{"type":"org.apache.brooklyn.api.entity.Entity","id":"rbfvau9i75"}},{"entitlementContext":{"user":"<snip>","sourceIp":"0:0:0:0:0:0:0:1","requestUri":"/v1/applications/rbfvau9i75/entities/rbfvau9i75/effectors/stop","requestUniqueIdentifier":"rjuSuB"}},{"wrappingType":"contextEntity","entity":{"type":"org.apache.brooklyn.api.entity.Entity","id":"rbfvau9i75"}}],"submitTimeUtc":1517490162402,"startTimeUtc":1517490162402,"endTimeUtc":null,"currentStatus":"In progress","result":null,"isError":false,"isCancelled":false,"children":[{"link":"/v1/activities/X9j8xcJ1","metadata":{"id":"X9j8xcJ1","taskName":"invoking stop[] on 1 node","entityId":"rbfvau9i75","entityDisplayName":"server @ localhost"}}],"submittedByTask":null,"blockingTask":{"link":"/v1/activities/X9j8xcJ1","metadata":{"id":"X9j8xcJ1","taskName":"invoking stop[] on 1 node","entityId":"rbfvau9i75","entityDisplayName":"server @ localhost"}},"detailedStatus":"Waiting on Task[invoking stop[] on 1 node]@X9j8xcJ1\n\nTask[stop]@kpML04c1\nChildren:\n  Task[invoking stop[] on 1 node]@X9j8xcJ1: Executing 1 child task\n\nIn progress, thread waiting (notify) on java.util.concurrent.FutureTask@61fe3136\nAt: com.google.common.util.concurrent.ForwardingFuture.get(ForwardingFuture.java:63)\n    org.apache.brooklyn.util.core.task.BasicTask.get(BasicTask.java:384)\n    org.apache.brooklyn.util.core.task.BasicTask.getUnchecked(BasicTask.java:393)\n    org.apache.brooklyn.util.core.task.DynamicTasks$TaskQueueingResult.andWaitForSuccess(DynamicTasks.java:195)\n    org.apache.brooklyn.util.core.task.DynamicTasks.get(DynamicTasks.java:363)\n    org.apache.brooklyn.core.entity.trait.StartableMethods.stop(StartableMethods.java:58)\n    org.apache.brooklyn.core.entity.AbstractApplication.doStop(AbstractApplication.java:271)\n    org.apache.brooklyn.core.entity.AbstractApplication.stop(AbstractApplication.java:246)\n    org.apache.brooklyn.util.javalang.Reflections.invokeMethodFromArgs(Reflections.java:984)\n    org.apache.brooklyn.util.javalang.Reflections.invokeMethodFromArgs(Reflections.java:871)\n    org.apache.brooklyn.util.javalang.Reflections.invokeMethodFromArgs(Reflections.java:857)\n    org.apache.brooklyn.util.javalang.Reflections.invokeMethodFromArgs(Reflections.java:852)\n    org.apache.brooklyn.core.mgmt.internal.AbstractManagementContext.invokeEffectorMethodLocal(AbstractManagementContext.java:327)\n    org.apache.brooklyn.core.mgmt.internal.AbstractManagementContext.invokeEffectorMethodSync(AbstractManagementContext.java:366)\n    org.apache.brooklyn.core.mgmt.internal.EffectorUtils.invokeMethodEffector(EffectorUtils.java:274)\n    org.apache.brooklyn.core.effector.MethodEffector.call(MethodEffector.java:153)\n    org.apache.brooklyn.core.entity.trait.Startable$StopEffectorBody.call(Startable.java:68)\n    org.apache.brooklyn.core.entity.trait.Startable$StopEffectorBody.call(Startable.java:60)\n    org.apache.brooklyn.core.effector.EffectorTasks$EffectorBodyTaskFactory$1.call(EffectorTasks.java:82)\n    org.apache.brooklyn.util.core.task.DynamicSequentialTask$DstJob.call(DynamicSequentialTask.java:364)\n    org.apache.brooklyn.util.core.task.BasicExecutionManager$SubmissionCallable.call(BasicExecutionManager.java:565)","streams":{},"links":{"self":"/v1/activities/kpML04c1","children":"/v1/activities/kpML04c1/children","entity":"/v1/applications/rbfvau9i75/entities/rbfvau9i75"}}
```
