### PR TITLE
fix jenkins docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@
 # under the License.
 
 # For Brooklyn Client, we use a debian distribution instead of alpine as there are some libgcc incompatibilities with GO
-FROM maven:3.5.2-jdk-8-slim
+FROM maven:3.5.4-jdk-8-slim
 
 # Install necessary binaries to build brooklyn-client
 RUN apt-get update && apt-get install -y git-core golang-go
+
+RUN mkdir -p /var/maven/.m2/ && chmod -R 777 /var/maven/


### PR DESCRIPTION
Jenkins build failed writing to /var/maven/.brooklyn
```
2018-09-27 18:58:15,450 INFO  - TESTNG INVOKING CONFIGURATION: "Surefire test" - @BeforeClass org.apache.brooklyn.rest.client.BrooklynApiRestClientTest.setUp()
2018-09-27 18:58:15,875 INFO  - Added external config supplier named 'brooklyn-demo-sample': org.apache.brooklyn.core.config.external.InPlaceExternalConfigSupplier@545f80bf
ERROR: Unable to create cache directory: /var/maven/.brooklyn/osgi/cache/Y2SkyHlG
ERROR: Error creating bundle cache.
java.lang.RuntimeException: Unable to create cache directory.
	at org.apache.felix.framework.cache.BundleCache.<init>(BundleCache.java:131)
	at org.apache.felix.framework.Felix.init(Felix.java:692)
	at org.apache.felix.framework.Felix.init(Felix.java:626)
```