### PR TITLE
Fix for SUREFIRE-1588

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -302,6 +302,7 @@
                                 <cobertura.user.java.nio>false</cobertura.user.java.nio>
                             </systemPropertyVariables>
                             <printSummary>true</printSummary>
+                            <useSystemClassLoader>false</useSystemClassLoader>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
Latest version of Java 1.8.0_191 enforces that Manifest classpath entries be
relative.

https://issues.apache.org/jira/browse/SUREFIRE-1588