### PR TITLE
bump resteasy to be compatible with new jersey

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -34,7 +34,7 @@
     </parent>
 
     <properties>
-      <resteasy.version>3.0.19.Final</resteasy.version>
+      <resteasy.version>3.6.2.Final</resteasy.version>
     </properties>
 
     <dependencies>

--- a/java/src/main/java/org/apache/brooklyn/rest/client/BrooklynApi.java
+++ b/java/src/main/java/org/apache/brooklyn/rest/client/BrooklynApi.java
@@ -61,6 +61,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.jboss.resteasy.client.ClientExecutor;
+import org.jboss.resteasy.client.ClientRequest;
 import org.jboss.resteasy.client.ClientResponse;
 import org.jboss.resteasy.client.ProxyBuilder;
 import org.jboss.resteasy.client.core.executors.ApacheHttpClient4Executor;
@@ -168,7 +169,13 @@ public class BrooklynApi {
                 .setConnectionManager(connectionManagerSupplier.get())
                 .build();
 
-        return new ApacheHttpClient4Executor(httpClient);
+        return new ApacheHttpClient4Executor(httpClient) {
+            @Override
+            public ClientResponse execute(ClientRequest request) throws Exception {
+                request.header("X-Csrf-Token-Required-For-Requests", "none");
+                return super.execute(request);
+            }
+        };
     }
 
     /**


### PR DESCRIPTION
fix need for csrf header now that that is respected in tests

needed following https://github.com/apache/brooklyn-server/pull/1024